### PR TITLE
[FIX] Fix the URL of repo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                 </a>
                 <ul class="right">
                     <li>
-                        <a class="waves-effect waves-light btn-flat white-text" href="https://john29917958.github.io/Painter/">
+                        <a class="waves-effect waves-light btn-flat white-text" href="https://github.com/john29917958/Painter">
                             <i class="material-icons left">insert_link</i>
                             GitHub
                         </a>
@@ -34,6 +34,6 @@
     <canvas class="grey white" id="canvas"></canvas>
 </body>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-<script src="./js/app.js" type="text/javascript"></script>
+<script src="./js/app.js" type="module"></script>
 
 </html>


### PR DESCRIPTION
This is a pull-request for #1. Fix the URL for the href attribute in the GitHub <a> tag link which is located at the right on the navigation bar.